### PR TITLE
Disable check certificate for old iOS (Sectigo CA doesn't include in …

### DIFF
--- a/PUAPI/Sources/PUAPI/Client/NetworkClientCertificate.swift
+++ b/PUAPI/Sources/PUAPI/Client/NetworkClientCertificate.swift
@@ -52,8 +52,11 @@ struct NetworkClientCertificate {
       &trust)
 
     guard status == noErr else { return nil }
-    guard SecTrustEvaluateWithError(trust, &error) else {
-      return nil
+
+    if #available(iOS 17.4, *) {
+      guard SecTrustEvaluateWithError(trust, &error) else {
+        return nil
+      }
     }
 
     return SecTrustCopyPublicKey(trust)


### PR DESCRIPTION
…system bundle)